### PR TITLE
Fixed spelling error in create_rsvp_database.sql

### DIFF
--- a/mysql/create_rsvp_database.sql
+++ b/mysql/create_rsvp_database.sql
@@ -14,7 +14,7 @@ CREATE TABLE admin_users (
 CREATE TABLE parties (
     id INT AUTO_INCREMENT,
     nickname VARCHAR(255) NULL,
-    PRIARY KEY (id)
+    PRIMARY KEY (id)
 );
 
 CREATE TABLE party_emails (


### PR DESCRIPTION
I was trying to run the code and MySQL chocked on that row.
